### PR TITLE
回答・質問の個別Slack通知先チャンネルの追加・通知用ドメインの修正

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,6 +11,8 @@ API_SESSION_EXPIRE_MINUTES=10080
 # RAILS_LOG_TO_STDOUT=1
 
 # SLACK_WEBHOOK_URL=https://hooks.slack.com/services/HOGEHOGE
+# SLACK_ANSWER_CHANNEL=notification-score-server-answer
+# SLACK_QUESTION_CHANNEL=notification-score-server-question
 # BUGSNAG_API_KEY=
 
 POSTGRES_HOST=db

--- a/.env.sample
+++ b/.env.sample
@@ -13,6 +13,7 @@ API_SESSION_EXPIRE_MINUTES=10080
 # SLACK_WEBHOOK_URL=https://hooks.slack.com/services/HOGEHOGE
 # SLACK_ANSWER_CHANNEL=notification-score-server-answer
 # SLACK_QUESTION_CHANNEL=notification-score-server-question
+# SCORE_SERVER_DOMAIN=https://netcon.janog.gr.jp
 # BUGSNAG_API_KEY=
 
 POSTGRES_HOST=db

--- a/api/app/graphql/notification.rb
+++ b/api/app/graphql/notification.rb
@@ -8,7 +8,7 @@ class Notification
       Rails.logger.debug { "Notification published #{mutation}".green }
 
       slack_message = build_slack_message(mutation: mutation, record: record)
-      SlackNotifierJob.perform_later(slack_message) if slack_message.present?
+      SlackNotifierJob.perform_later(slack_message, mutation: mutation) if slack_message.present?
 
       # 非同期通知が原因でリクエストが失敗しないようにする
     rescue StandardError => e

--- a/api/app/graphql/notification.rb
+++ b/api/app/graphql/notification.rb
@@ -171,6 +171,7 @@ class Notification
         <<~MSG
           #{problem.writer} 質問追加
           #{build_team_and_problem_summary(team: issue.team, problem: problem)}
+          リンク: #{Rails.application.config.score_server_domain}/problems/#{record.problem_id}#issues=#{record.team_id}
         MSG
       else
         nil

--- a/api/app/graphql/notification.rb
+++ b/api/app/graphql/notification.rb
@@ -151,11 +151,10 @@ class Notification
 
       case mutation
       when 'AddAnswer'
-        # TODO: ホスト名がハードコードされているのを環境変数か何かで解消する
         <<~MSG
           #{record.problem.writer} 解答提出
           #{build_team_and_problem_summary(team: record.team, problem: record.problem)}
-          リンク: https://netcon.janog.gr.jp/problems/#{record.problem_id}#answers=#{record.team_id}
+          リンク: #{Rails.application.config.score_server_domain}/problems/#{record.problem_id}#answers=#{record.team_id}
         MSG
       when 'AddPenalty'
         # メンションしない

--- a/api/app/jobs/slack_notifier_job.rb
+++ b/api/app/jobs/slack_notifier_job.rb
@@ -8,10 +8,19 @@
 class SlackNotifierJob < ApplicationJob
   queue_as :default
 
-  def perform(message)
-    return if Rails.application.config.slack_webhook_url.blank?
+  def perform(message, mutation)
+    return if Rails.application.config.slack_webhook_url.blank? or RaRails.application.config.slack_answer_channel or Rails.application.config.slack_question_channel
 
-    notifier = Slack::Notifier.new(Rails.application.config.slack_webhook_url)
+    case mutation
+    when "AddAnswer"
+      notifier = Slack::Notifier.new(Rails.application.config.slack_webhook_url) do
+        defaults channel: Rails.application.config.slack_answer_channel
+      end
+    when 'AddIssueComment', 'StartIssue'
+      notifier = Slack::Notifier.new(Rails.application.config.slack_webhook_url) do
+        defaults channel: Rails.application.config.slack_question_channel
+      end
+
     notifier.ping(message)
   end
 end

--- a/api/config/initializers/slack.rb
+++ b/api/config/initializers/slack.rb
@@ -4,3 +4,4 @@
 Rails.application.config.slack_webhook_url = ENV['SLACK_WEBHOOK_URL']
 Rails.application.config.slack_answer_channel = ENV['SLACK_ANSWER_CHANNEL']
 Rails.application.config.slack_question_channel = ENV['SLACK_QUESTION_CHANNEL']
+Rails.application.config.score_server_domain = ENV['SCORE_SERVER_DOMAIN']

--- a/api/config/initializers/slack.rb
+++ b/api/config/initializers/slack.rb
@@ -2,3 +2,5 @@
 
 # null許容
 Rails.application.config.slack_webhook_url = ENV['SLACK_WEBHOOK_URL']
+Rails.application.config.slack_answer_channel = ENV['SLACK_ANSWER_CHANNEL']
+Rails.application.config.slack_question_channel = ENV['SLACK_QUESTION_CHANNEL']


### PR DESCRIPTION
- 回答と質問で通知先のチャンネルを分けれるようにした
- 回答と質問の通知リンクをenvで参照できるようにした
- 質問のメッセージにもリンクを追加
