### PR TITLE
JANOG51で開発するためのdocker-composeの変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 NETCON Score Server
 ---
 
-The contest site for [JANOG50 NETCON](https://www.janog.gr.jp/meeting/janog49).
+The contest site for [JANOG51 NETCON](https://www.janog.gr.jp/meeting/janog51).
 
 It's called also *score server*.  The main feature of this is to propose problem and marking.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,38 +80,38 @@ services:
       - db
     ports: ['127.0.0.1:8905:8080']
 
-  vm-management-service:
-    image: kyontan/netcon-score-server:vm-management-service
-    ports: ['127.0.0.1:8951:80', '127.0.0.1:8950:81']
-    volumes:
-      - './vm-management-service-conf-d:/etc/nginx/conf.d'
-      - './vm-management-service-log:/var/log'
+  #vm-management-service:
+  #  image: kyontan/netcon-score-server:vm-management-service
+  #  ports: ['127.0.0.1:8951:80', '127.0.0.1:8950:81']
+  #  volumes:
+  #    - './vm-management-service-conf-d:/etc/nginx/conf.d'
+  #    - './vm-management-service-log:/var/log'
 
-  scheduler:
-    image: kyontan/netcon-score-server:scheduler
-    tty: true
-    volumes:
-      - './scheduler.yaml:/scheduler.yaml'
-      - './scheduler-log:/scheduler-log'
-    command: ["scheduler", "start", "--config", "/scheduler.yaml", "--log-file-path", "/scheduler-log/scheduler.log"]
-    # oneshotで実行する場合
-    #command: ["scheduler", "start", "--config", "/scheduler.yaml", "--oneshot"]
+  #scheduler:
+  #  image: kyontan/netcon-score-server:scheduler
+  #  tty: true
+  #  volumes:
+  #    - './scheduler.yaml:/scheduler.yaml'
+  #    - './scheduler-log:/scheduler-log'
+  #  command: ["scheduler", "start", "--config", "/scheduler.yaml", "--log-file-path", "/scheduler-log/scheduler.log"]
+  #  # oneshotで実行する場合
+  #  #command: ["scheduler", "start", "--config", "/scheduler.yaml", "--oneshot"]
 
-  coordinator:
-    image: kyontan/netcon-score-server:coordinator
-    tty: true
-    volumes:
-      - './networkcontest-58d9c7749479.json:/var/app/creds.json'
-    environment:
-      - GOOGLE_APPLICATION_CREDENTIALS=/var/app/creds.json
-    command: ["--auth_type", "sa", "--project", "networkcontest", "--zones", "asia-northeast1-b", "asia-northeast2-a", "asia-east1-b", "--vmdb_url", "http://vmdb-api:8080", "--loop", "true", "--loop_interval", "60"]
-    # dry_runしてinterval10秒
-    #command: ["--dry_run", "true", "--auth_type", "sa", "--project", "networkcontest", "--zones", "asia-northeast1-b", "asia-northeast2-a", "asia-east1-b", "--vmdb_url", "http://vmdb-api:8080", "--loop", "true", "--loop_interval", "10"]
+  #coordinator:
+  #  image: kyontan/netcon-score-server:coordinator
+  #  tty: true
+  #  volumes:
+  #    - './networkcontest-58d9c7749479.json:/var/app/creds.json'
+  #  environment:
+  #    - GOOGLE_APPLICATION_CREDENTIALS=/var/app/creds.json
+  #  command: ["--auth_type", "sa", "--project", "networkcontest", "--zones", "asia-northeast1-b", "asia-northeast2-a", "asia-east1-b", "--vmdb_url", "http://vmdb-api:8080", "--loop", "true", "--loop_interval", "60"]
+  #  # dry_runしてinterval10秒
+  #  #command: ["--dry_run", "true", "--auth_type", "sa", "--project", "networkcontest", "--zones", "asia-northeast1-b", "asia-northeast2-a", "asia-east1-b", "--vmdb_url", "http://vmdb-api:8080", "--loop", "true", "--loop_interval", "10"]
 
-  exporter:
-    image: kyontan/netcon-score-server-exporter:latest
-    env_file: .env
-    ports: ['127.0.0.1:8906:4567']
+  #exporter:
+  #  image: kyontan/netcon-score-server-exporter:latest
+  #  env_file: .env
+  #  ports: ['127.0.0.1:8906:4567']
 
 volumes:
   pgdata:

--- a/ui/nuxt.config.js
+++ b/ui/nuxt.config.js
@@ -6,14 +6,14 @@ export default {
   },
   head: {
     title: 'スコアサーバー',
-    titleTemplate: '%s | JANOG50 NETCON',
+    titleTemplate: '%s | JANOG51 NETCON',
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       {
         hid: 'description',
         name: 'description',
-        content: 'JANOG50 NETCON スコアサーバー',
+        content: 'JANOG51 NETCON スコアサーバー',
       },
     ],
     link: [{ rel: 'icon', type: 'image/png', href: '/favicon.png' }],


### PR DESCRIPTION
- JANOG51で使用しないであろうサービスのコメント化
- 一部のテキストの変更
  - JANOG50->JANOG51

## Develop Quick Start
```
git clone git@github.com:janog-netcon/netcon-score-server.git
cd netcon-score-server
cp .env.sample .env
docker compose build
docker compose up -d

# .envがdevelopの場合は下記を実行してテストデータを入れる
# docker compose exec api bundle exec rails db:setup
```

## アクセス方法のサンプル

用途 | URL
-- | --
UI | http://localhost:8901
API ログイン/ログアウト | http://localhost:8900/api/sessions
API GraphQLエンドポイント | http://localhost:8900/api/graphql

## 開発環境で用意されるユーザー
<p>パスワードはユーザー名と同じ</p>


権限 | ユーザー名
-- | --
staff | staff
audience | audience
player | team a
player | team b (a ~ brぐらいまである)


