### PR TITLE
fix: fix 500 error when scoreboards are empty

### DIFF
--- a/api/app/models/score_aggregator.rb
+++ b/api/app/models/score_aggregator.rb
@@ -44,7 +44,7 @@ class ScoreAggregator
       teams
         .map {|team| build_record(team: team, team_answers: teams_answers[team.id], penalty_score: teams_penalty_scores[team.id]) }
         .group_by {|record| record[:team].beginner }
-        .sum {|_key, records| assign_rank(records: records) }
+        .sum([]) {|_key, records| assign_rank(records: records) }
     end
 
     private


### PR DESCRIPTION
When there are no answers or teams (e.g., initial state), the scoreboard aggregation logic failed because `.sum` was called on an empty collection without an initial value, returning `0` instead of `[]`. This caused a type error in GraphQL response.

This PR initializes `.sum([])` to ensure an array is always returned.