### PR TITLE
Fix scoreboard ranking display order

### DIFF
--- a/ui/components/summary/ReportCardTable.vue
+++ b/ui/components/summary/ReportCardTable.vue
@@ -81,7 +81,7 @@ export default {
   name: 'ReportCardTable',
   computed: {
     reportCards() {
-      return orm.ReportCard.all()
+      return orm.ReportCard.query().orderBy('rank').all()
     },
     problemTitles() {
       if (this.reportCards.length === 0) {

--- a/ui/components/top/ScoreboardPanel.vue
+++ b/ui/components/top/ScoreboardPanel.vue
@@ -35,7 +35,7 @@ export default {
   },
   computed: {
     scoreboards() {
-      return orm.Scoreboard.query().with('team').all()
+      return orm.Scoreboard.query().with('team').orderBy('rank').all()
     },
     beginnerScoreboards() {
       return this.scoreboards.filter((sb) => sb.team.beginner)


### PR DESCRIPTION
## 概要

VuexORMの `.all()` は挿入順やソート順を保証しないため、スコアボードと成績表の順位表示がランク順になっていなかった問題を修正します。

## 変更内容

- `ScoreboardPanel.vue`: `.orderBy('rank')` を追加してランク順に表示
- `ReportCardTable.vue`: `.orderBy('rank')` を追加してランク順に表示

## 原因

バックエンド側の `ScoreAggregator.assign_rank` はスコア・満点数で正しくソートした上でランクを付与していますが、フロントエンド側のVuexORMストアから取得する際にソートなしの `.all()` を使っていたため、表示順がランク順にならないケースがありました。